### PR TITLE
Fix expect, include header for execvpe and fix ttyp/ptyp file resolution

### DIFF
--- a/patches/exp_clib.c.patch
+++ b/patches/exp_clib.c.patch
@@ -1,0 +1,12 @@
+diff --git a/exp_clib.c b/exp_clib.c
+index 1699775..d463a77 100644
+--- a/exp_clib.c
++++ b/exp_clib.c
+@@ -9,6 +9,7 @@ would appreciate credit if this program or parts of it are used.
+ 
+ #include "expect_cf.h"
+ #include <stdio.h>
++#include <unistd.h>
+ #include <setjmp.h>
+ #ifdef HAVE_INTTYPES_H
+ #  include <inttypes.h>

--- a/patches/pty_termios.c.patch
+++ b/patches/pty_termios.c.patch
@@ -1,0 +1,36 @@
+diff --git a/pty_termios.c b/pty_termios.c
+index c605b23..ffc0a0d 100644
+--- a/pty_termios.c
++++ b/pty_termios.c
+@@ -487,7 +487,7 @@ exp_getptymaster()
+ 	 */
+ 	if (exp_pty_test_start() == -1) return -1;
+ 
+-#if !defined(HAVE_CONVEX_GETPTY) && !defined(HAVE_PTYM) && !defined(HAVE_SCO_CLIST_PTYS)
++#if !defined(HAVE_CONVEX_GETPTY) && !defined(HAVE_PTYM) && !defined(HAVE_SCO_CLIST_PTYS) && !defined(__MVS__)
+ 	for (bank = banks;*bank;bank++) {
+ 		*tty_bank = *bank;
+ 		*tty_num = '0';
+@@ -518,6 +518,22 @@ exp_getptymaster()
+         }
+ #endif
+ 
++#if defined(__MVS__)
++        for (num = 0; ; num++) {
++            char num_str [16];
++
++            sprintf (num_str, "%02d", num);
++            sprintf (master_name, "%s%s", "/dev/ptyp00", num_str);
++            if (stat (master_name, &stat_buf) < 0)
++                break;
++            sprintf (slave_name, "%s%s", "/dev/ttyp00", num_str);
++
++            master = exp_pty_test(master_name,slave_name,'0',num_str);
++            if (master >= 0)
++                goto done;
++        }
++#endif
++
+ #ifdef HAVE_PTYM
+ 	/* systems with PTYM follow this idea:
+ 

--- a/tests/zopen.sh
+++ b/tests/zopen.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env expect -f
+spawn zopen -h
 
-spawn zopen-generate
+# set the prompt to a known value
+expect -re {zopen build}
+
+# send a command: we don't know what the output is going to be
+spawn echo "HI"


### PR DESCRIPTION
This fixes https://github.com/ZOSOpenTools/expectport/issues/1